### PR TITLE
Feature/15 user

### DIFF
--- a/src/main/java/com/kusithm/meetupd/domain/grade/entity/Grade.java
+++ b/src/main/java/com/kusithm/meetupd/domain/grade/entity/Grade.java
@@ -1,0 +1,30 @@
+package com.kusithm.meetupd.domain.grade.entity;
+
+import com.kusithm.meetupd.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity(name = "GRADE")
+public class Grade extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "grade_id")
+    private Long id;
+
+    @Column(name = "type", nullable = false)
+    private TYPE userType;
+
+    @Column(name = "buy_time", nullable = false)
+    private Timestamp buyTime;
+
+    @Column(name = "end_time", nullable = false)
+    private Timestamp endTime;
+
+}

--- a/src/main/java/com/kusithm/meetupd/domain/grade/entity/TYPE.java
+++ b/src/main/java/com/kusithm/meetupd/domain/grade/entity/TYPE.java
@@ -1,0 +1,6 @@
+package com.kusithm.meetupd.domain.grade.entity;
+
+public enum TYPE {
+
+    FREE, PAID
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/Carrer.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/Carrer.java
@@ -1,0 +1,21 @@
+package com.kusithm.meetupd.domain.user.entity;
+
+import com.kusithm.meetupd.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity(name = "USER_CARRER")
+public class Carrer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "carrer_id")
+    private Long id;
+
+    @Column(name = "carrer", nullable = false)
+    private String carrer;
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/GENDER.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/GENDER.java
@@ -1,0 +1,5 @@
+package com.kusithm.meetupd.domain.user.entity;
+
+public enum GENDER {
+    M,F,ETC
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/Major.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/Major.java
@@ -1,0 +1,20 @@
+package com.kusithm.meetupd.domain.user.entity;
+
+import com.kusithm.meetupd.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity(name = "USER_MAJOR")
+public class Major extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "major_id")
+    private Long id;
+
+    @Column(name = "major", nullable = false)
+    private String major;
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/Skill.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/Skill.java
@@ -1,0 +1,20 @@
+package com.kusithm.meetupd.domain.user.entity;
+
+import com.kusithm.meetupd.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity(name = "USER_SKILL")
+public class Skill extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "skill_id")
+    private Long id;
+
+    @Column(name = "skill", nullable = false)
+    private String skill;
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/Task.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/Task.java
@@ -1,0 +1,20 @@
+package com.kusithm.meetupd.domain.user.entity;
+
+import com.kusithm.meetupd.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity(name = "USER_TASK")
+public class Task extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "task_id")
+    private Long id;
+
+    @Column(name = "task", nullable = false)
+    private String task;
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
@@ -1,14 +1,17 @@
 package com.kusithm.meetupd.domain.user.entity;
 
+import com.kusithm.meetupd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.Date;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Entity(name = "WANTEAM_USER")
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,6 +32,24 @@ public class User {
 
     @Column(name = "profile_image", nullable = true)
     private String profileImage;
+
+    @Column(name = "birth_day", nullable = false)
+    private Date birth_day;
+
+    @Column(name = "gender", nullable = false)
+    private GENDER gender;
+
+    @Column(name = "major", nullable = false)
+    private String major;
+
+    @Column(name = "task", nullable = false)
+    private String task;
+
+    @Column(name = "career", nullable = true)
+    private String career;
+
+    @Column(name = "skill", nullable = true)
+    private String skill;
 
 
     public static User createUser(Long kakaoId, String username, Integer age, String email) {

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
@@ -39,18 +39,6 @@ public class User extends BaseEntity {
     @Column(name = "gender", nullable = false)
     private GENDER gender;
 
-    @Column(name = "major", nullable = false)
-    private String major;
-
-    @Column(name = "task", nullable = false)
-    private String task;
-
-    @Column(name = "career", nullable = true)
-    private String career;
-
-    @Column(name = "skill", nullable = true)
-    private String skill;
-
 
     public static User createUser(Long kakaoId, String username, Integer age, String email) {
         User user = User.builder()


### PR DESCRIPTION
## Related Issue 🪢

- close : #15 

## Summary 🌿

- 기존 User 엔터티에서 erd에 맞게 수정했습니다.
- Grade(회원 등급)엔터티 생성했습니다.

## Before i request PR review 🧤
- 아직 User와 Grade 연관관계 설정은 하지 않았습니다.

## Check Please🙏
- User 엔터티에서 전공, 직무, 이력, 스킬 칼럼은 다중 입력이 가능해서 erd를 수정해야 할 것 같습니다. 테이블을 따로 빼던지, MySQL 5.7.8 버전부터  JSON 타입을 이용해 배열 데이터를 저장할 수 있다고 하는데 어떤 방법으로 하는 게 좋을까요?
정해지는 대로 수정해 두겠습니다.
