### PR TITLE
티켓 개수 조회 및 구매 API 추가

### DIFF
--- a/src/main/java/com/kusithm/meetupd/domain/user/controller/UserController.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/controller/UserController.java
@@ -37,4 +37,9 @@ public class UserController {
         return SuccessResponse.of(SuccessCode.OK, response);
     }
 
+    @GetMapping("/tickets/count")
+    public ResponseEntity<SuccessResponse<UserTicketCountResponseDto>> getUserTicketCount(@UserId Long userId) {
+        UserTicketCountResponseDto response = userService.getUserTicketCount(userId);
+        return SuccessResponse.of(SuccessCode.OK, response);
+    }
 }

--- a/src/main/java/com/kusithm/meetupd/domain/user/controller/UserController.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/controller/UserController.java
@@ -5,7 +5,7 @@ import com.kusithm.meetupd.common.dto.SuccessResponse;
 import com.kusithm.meetupd.common.dto.code.SuccessCode;
 import com.kusithm.meetupd.domain.user.dto.UserMypageResponseDto;
 import com.kusithm.meetupd.domain.user.dto.request.BuyUserTicketRequestDto;
-import com.kusithm.meetupd.domain.user.dto.response.BuyUserTicketResponseDto;
+import com.kusithm.meetupd.domain.user.dto.response.UserTicketCountResponseDto;
 import com.kusithm.meetupd.domain.user.dto.response.UserCheckResponseDto;
 import com.kusithm.meetupd.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -31,9 +31,9 @@ public class UserController {
         return SuccessResponse.of(SuccessCode.OK, response);
     }
 
-    @PatchMapping("/tickets/{userId}/add")
-    public ResponseEntity<SuccessResponse<BuyUserTicketResponseDto>> buyUserTicket(@UserId Long userId, @RequestBody BuyUserTicketRequestDto request) {
-        BuyUserTicketResponseDto response = userService.buyUserTicket(userId, request);
+    @PatchMapping("/tickets/buy")
+    public ResponseEntity<SuccessResponse<UserTicketCountResponseDto>> buyUserTicket(@UserId Long userId, @RequestBody BuyUserTicketRequestDto request) {
+        UserTicketCountResponseDto response = userService.buyUserTicket(userId, request);
         return SuccessResponse.of(SuccessCode.OK, response);
     }
 

--- a/src/main/java/com/kusithm/meetupd/domain/user/controller/UserController.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/controller/UserController.java
@@ -4,6 +4,8 @@ import com.kusithm.meetupd.common.auth.UserId;
 import com.kusithm.meetupd.common.dto.SuccessResponse;
 import com.kusithm.meetupd.common.dto.code.SuccessCode;
 import com.kusithm.meetupd.domain.user.dto.UserMypageResponseDto;
+import com.kusithm.meetupd.domain.user.dto.request.BuyUserTicketRequestDto;
+import com.kusithm.meetupd.domain.user.dto.response.BuyUserTicketResponseDto;
 import com.kusithm.meetupd.domain.user.dto.response.UserCheckResponseDto;
 import com.kusithm.meetupd.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +31,10 @@ public class UserController {
         return SuccessResponse.of(SuccessCode.OK, response);
     }
 
+    @PatchMapping("/tickets/{userId}/add")
+    public ResponseEntity<SuccessResponse<BuyUserTicketResponseDto>> buyUserTicket(@UserId Long userId, @RequestBody BuyUserTicketRequestDto request) {
+        BuyUserTicketResponseDto response = userService.buyUserTicket(userId, request);
+        return SuccessResponse.of(SuccessCode.OK, response);
+    }
 
 }

--- a/src/main/java/com/kusithm/meetupd/domain/user/dto/request/BuyUserTicketRequestDto.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/dto/request/BuyUserTicketRequestDto.java
@@ -1,0 +1,9 @@
+package com.kusithm.meetupd.domain.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class BuyUserTicketRequestDto {
+
+    private Integer buyAmount;
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/dto/response/BuyUserTicketResponseDto.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/dto/response/BuyUserTicketResponseDto.java
@@ -1,0 +1,18 @@
+package com.kusithm.meetupd.domain.user.dto.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class BuyUserTicketResponseDto {
+
+    private Integer ticketCount;
+
+    public static BuyUserTicketResponseDto of(Integer ticketCount) {
+        return BuyUserTicketResponseDto.builder()
+                .ticketCount(ticketCount)
+                .build();
+    }
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/dto/response/UserTicketCountResponseDto.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/dto/response/UserTicketCountResponseDto.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class BuyUserTicketResponseDto {
+public class UserTicketCountResponseDto {
 
     private Integer ticketCount;
 
-    public static BuyUserTicketResponseDto of(Integer ticketCount) {
-        return BuyUserTicketResponseDto.builder()
+    public static UserTicketCountResponseDto of(Integer ticketCount) {
+        return UserTicketCountResponseDto.builder()
                 .ticketCount(ticketCount)
                 .build();
     }

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/Ticket.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/Ticket.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Entity
+@Entity(name = "USER_TICKET")
 public class Ticket extends BaseEntity {
 
     @Id
@@ -20,10 +20,19 @@ public class Ticket extends BaseEntity {
     @Column(name = "count")
     private Integer count;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     public static Ticket createInitTicket() {
         return Ticket.builder()
                 .count(0)
                 .build();
+    }
+
+    public void changeUser(User user) {
+        this.user = user;
+        user.updateTicket(this);
     }
 
     public void addTicketCount(Integer amount) {

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/Ticket.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/Ticket.java
@@ -1,0 +1,36 @@
+package com.kusithm.meetupd.domain.user.entity;
+
+
+import com.kusithm.meetupd.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+public class Ticket extends BaseEntity {
+
+    @Id
+    @Column(name = "ticket_id")
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "count")
+    private Integer count;
+
+    public static Ticket createInitTicket() {
+        return Ticket.builder()
+                .count(0)
+                .build();
+    }
+
+    public void addTicketCount(Integer amount) {
+        this.count += amount;
+    }
+
+    public void spendTicket() {
+        this.count -= 1;
+    }
+}

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
@@ -68,8 +68,7 @@ public class User extends BaseEntity {
     private List<Certificate> certificates = new ArrayList<>(); // 자격증
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @Builder.Default
-    public Ticket ticket = createInitTicket();
+    public Ticket ticket;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
@@ -101,11 +100,18 @@ public class User extends BaseEntity {
         Task createdTask = createTask(task);
         createdTask.updateUser(user);
 
+        Ticket ticket = createInitTicket();
+        ticket.changeUser(user);
+
         return user;
     }
 
     public void updateLocation(Location location) {
         this.location = location;
+    }
+
+    public void updateTicket(Ticket ticket) {
+        this.ticket = ticket;
     }
 
     public void addMajor(Major major) {

--- a/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/entity/User.java
@@ -11,6 +11,7 @@ import java.util.List;
 import static com.kusithm.meetupd.domain.user.entity.Location.craeteLocation;
 import static com.kusithm.meetupd.domain.user.entity.Major.createMajor;
 import static com.kusithm.meetupd.domain.user.entity.Task.createTask;
+import static com.kusithm.meetupd.domain.user.entity.Ticket.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,37 +40,40 @@ public class User extends BaseEntity {
     @Column(name="self_introduction",nullable = false)
     private String selfIntroduction;
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Major> majors = new ArrayList<>(); // 전공
 
-    @OneToOne(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Location location;  // 지역
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Task> tasks = new ArrayList<>();   //희망 직무
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Internship> internships = new ArrayList<>();   // 인턴쉽
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Award> awards = new ArrayList<>(); // 수상내역
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Tool> tools = new ArrayList<>();   // 사용 툴
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Certificate> certificates = new ArrayList<>(); // 자격증
 
-    @OneToMany(mappedBy = "user",cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Builder.Default
+    public Ticket ticket = createInitTicket();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<TeamUser> teamUsers = new ArrayList<>();
-
 
     public static User createRegisterUser(String username,
                                   Integer location,
@@ -110,5 +114,9 @@ public class User extends BaseEntity {
 
     public void addTask(Task task) {
         this.tasks.add(task);
+    }
+
+    public Integer getTicketCount() {
+        return this.ticket.getCount();
     }
 }

--- a/src/main/java/com/kusithm/meetupd/domain/user/service/UserService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/service/UserService.java
@@ -4,17 +4,13 @@ import com.kusithm.meetupd.common.error.EntityNotFoundException;
 import com.kusithm.meetupd.common.error.ErrorCode;
 import com.kusithm.meetupd.domain.user.dto.UserMypageResponseDto;
 import com.kusithm.meetupd.domain.user.dto.request.BuyUserTicketRequestDto;
-import com.kusithm.meetupd.domain.user.dto.response.BuyUserTicketResponseDto;
+import com.kusithm.meetupd.domain.user.dto.response.UserTicketCountResponseDto;
 import com.kusithm.meetupd.domain.user.dto.response.UserCheckResponseDto;
 import com.kusithm.meetupd.domain.user.entity.*;
 import com.kusithm.meetupd.domain.user.mysql.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
@@ -38,10 +34,10 @@ public class UserService {
         return new UserMypageResponseDto(findUser);
     }
 
-    public BuyUserTicketResponseDto buyUserTicket(Long userId, BuyUserTicketRequestDto request) {
+    public UserTicketCountResponseDto buyUserTicket(Long userId, BuyUserTicketRequestDto request) {
         User findUser = getUserByUserId(userId);
         addUserTicket(findUser, request.getBuyAmount());
-        return BuyUserTicketResponseDto.of(findUser.getTicketCount());
+        return UserTicketCountResponseDto.of(findUser.getTicketCount());
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/main/java/com/kusithm/meetupd/domain/user/service/UserService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.kusithm.meetupd.domain.user.service;
 import com.kusithm.meetupd.common.error.EntityNotFoundException;
 import com.kusithm.meetupd.common.error.ErrorCode;
 import com.kusithm.meetupd.domain.user.dto.UserMypageResponseDto;
+import com.kusithm.meetupd.domain.user.dto.request.BuyUserTicketRequestDto;
+import com.kusithm.meetupd.domain.user.dto.response.BuyUserTicketResponseDto;
 import com.kusithm.meetupd.domain.user.dto.response.UserCheckResponseDto;
 import com.kusithm.meetupd.domain.user.entity.*;
 import com.kusithm.meetupd.domain.user.mysql.UserRepository;
@@ -30,14 +32,26 @@ public class UserService {
                 .username(findUser.getUsername())
                 .build();
     }
+
+    public UserMypageResponseDto getMypageUser(Long userId) {
+        User findUser = getUserByUserId(userId);
+        return new UserMypageResponseDto(findUser);
+    }
+
+    public BuyUserTicketResponseDto buyUserTicket(Long userId, BuyUserTicketRequestDto request) {
+        User findUser = getUserByUserId(userId);
+        addUserTicket(findUser, request.getBuyAmount());
+        return BuyUserTicketResponseDto.of(findUser.getTicketCount());
+    }
+
     private User getUserByUserId(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
         return user;
     }
 
-    public UserMypageResponseDto getMypageUser(Long userId) {
-        User findUser = getUserByUserId(userId);
-        return new UserMypageResponseDto(findUser);
+    private void addUserTicket(User user, Integer ticketAmount) {
+        user.ticket.addTicketCount(ticketAmount);
     }
+
 }

--- a/src/main/java/com/kusithm/meetupd/domain/user/service/UserService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/user/service/UserService.java
@@ -40,6 +40,11 @@ public class UserService {
         return UserTicketCountResponseDto.of(findUser.getTicketCount());
     }
 
+    public UserTicketCountResponseDto getUserTicketCount(Long userId) {
+        User findUser = getUserByUserId(userId);
+        return UserTicketCountResponseDto.of(findUser.getTicketCount());
+    }
+
     private User getUserByUserId(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
## Related Issue 🪢

- close : #40 

## Summary 🌿

- 티켓 개수 조회, 티켓 구매 API 를 추가했습니다.

## Before i request PR review 🧤

- 기존 등급 테이블 대신 Ticket 테이블로 바꾸고 Entity를 새로 만들었습니다.
<img width="266" alt="image" src="https://github.com/Kusitms-28th-Meetup-D/backend/assets/99639919/880f4859-e7e9-45ef-b9a4-2e5da2760d1c">

