### PR TITLE
공모전 상세 정보 보는 응답값 데이터 추가

### DIFF
--- a/src/main/java/com/kusithm/meetupd/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/controller/ContestController.java
@@ -23,10 +23,9 @@ public class ContestController {
 
     // 카테고리 공모전 조회 API
     @GetMapping("/categories")
-    public ResponseEntity<SuccessResponse<List<FindContestsResponseDto>>> findContests (@RequestParam(value = "searchStartDate", required = false, defaultValue = "20000101") @DateTimeFormat(pattern = "yyyyMMdd") LocalDate searchDate,
-                                                                                        @RequestParam(value = "contestType", required = false, defaultValue = "0") Integer contestType
+    public ResponseEntity<SuccessResponse<List<FindContestsResponseDto>>> findContests (@RequestParam(value = "contestType", required = false, defaultValue = "0") Integer contestType
     ) {
-        List<FindContestsResponseDto> response = contestService.findContestsByCategory(searchDate, contestType);
+        List<FindContestsResponseDto> response = contestService.findContestsByCategory(contestType);
         return SuccessResponse.of(SuccessCode.OK, response);
     }
 

--- a/src/main/java/com/kusithm/meetupd/domain/contest/dto/response/GetContestDetailInfoResponseDto.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/dto/response/GetContestDetailInfoResponseDto.java
@@ -5,6 +5,7 @@ import com.kusithm.meetupd.domain.contest.entity.ContestType;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.List;
@@ -23,6 +24,8 @@ public class GetContestDetailInfoResponseDto {
 
     private List<String> images;
 
+    private Long remainDay;
+
     private String description;
 
     private String recruitDate;
@@ -37,7 +40,7 @@ public class GetContestDetailInfoResponseDto {
 
     private String price;
 
-    public static GetContestDetailInfoResponseDto of(Contest contest) {
+    public static GetContestDetailInfoResponseDto of(Contest contest, LocalDate nowDate) {
         String recruitDate = "[접수기간]" + contest.getRecruitmentStartDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
                 + "(" + contest.getRecruitmentStartDate().getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN) + ") ~ "
                 + contest.getRecruitmentEndDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
@@ -47,6 +50,7 @@ public class GetContestDetailInfoResponseDto {
                 .contestId(contest.getId())
                 .title(contest.getTitle())
                 .images(contest.getContestImages())
+                .remainDay(DAYS.between(nowDate, contest.getRecruitmentEndDate()))
                 .description(contest.getDesc())
                 .recruitDate(recruitDate)
                 .types(contest.getTypes().stream()

--- a/src/main/java/com/kusithm/meetupd/domain/contest/mongo/ContestRepository.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/mongo/ContestRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.mongodb.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ContestRepository extends MongoRepository<Contest, String> {
 
@@ -18,5 +19,5 @@ public interface ContestRepository extends MongoRepository<Contest, String> {
     List<Contest> findContestsByDateAndType(LocalDate date, Integer num);
 
     @Query(value = "{_id : {$eq : ?0}}")
-    Contest findContestById(ObjectId contestId);
+    Optional<Contest> findContestById(ObjectId contestId);
 }

--- a/src/main/java/com/kusithm/meetupd/domain/contest/service/ContestService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/service/ContestService.java
@@ -33,14 +33,14 @@ public class ContestService {
     private final MongoConverter mongoConverter;
     private final MongoClient mongoClient;
 
-    public List<FindContestsResponseDto> findContestsByCategory(LocalDate nowDate, Integer contestType) {
+    public List<FindContestsResponseDto> findContestsByCategory(Integer contestType) {
         // 카테고리 전체 조회일 때
         if(isFindAllContest(contestType)) {
-            return findAllContests(nowDate);
+            return findAllContests(LocalDate.now());
         }
         else {
             validContestType(contestType);
-            return findContestsByType(nowDate, contestType);
+            return findContestsByType(LocalDate.now(), contestType);
         }
     }
 

--- a/src/main/java/com/kusithm/meetupd/domain/contest/service/ContestService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/service/ContestService.java
@@ -1,6 +1,8 @@
 package com.kusithm.meetupd.domain.contest.service;
 
 
+import com.kusithm.meetupd.common.error.EntityNotFoundException;
+import com.kusithm.meetupd.common.error.ErrorCode;
 import com.kusithm.meetupd.domain.contest.dto.response.FindContestsResponseDto;
 import com.kusithm.meetupd.domain.contest.dto.response.GetContestDetailInfoResponseDto;
 import com.kusithm.meetupd.domain.contest.entity.Contest;
@@ -43,24 +45,26 @@ public class ContestService {
     }
 
     public List<FindContestsResponseDto> findContestsBySearchText(String searchText) {
-
         List<Contest> contests = getContestsBySearchText(searchText);
-
         return createListOf(contests, LocalDate.now());
     }
 
     public GetContestDetailInfoResponseDto getContestDetailById(String contestId) {
         Contest findContest = getContestById(contestId);
-        return GetContestDetailInfoResponseDto.of(findContest);
+        return GetContestDetailInfoResponseDto.of(findContest, LocalDate.now());
     }
     private List<Contest> getContestsBySearchText(String searchText) {
         MongoDatabase database = mongoClient.getDatabase("wanteam-db");
         MongoCollection<Document> collection = database.getCollection("contest");
+        return searchContestByText(searchText, collection);
+    }
+
+    private List<Contest> searchContestByText(String searchText, MongoCollection<Document> collection) {
         AggregateIterable<Document> result = collection.aggregate(Arrays.asList(
                 new Document("$search",
                         new Document("index", "wanteam-db-contest")
-                        .append("text", new Document("query", searchText)
-                                .append("path", new Document("wildcard", "*"))))));
+                                .append("text", new Document("query", searchText)
+                                        .append("path", new Document("wildcard", "*"))))));
 
         List<Contest> contests = new ArrayList<>();
         result.forEach(doc -> contests.add(mongoConverter.read(Contest.class, doc)));
@@ -74,7 +78,6 @@ public class ContestService {
 
     private List<FindContestsResponseDto> findContestsByType(LocalDate nowDate, Integer contestType) {
         List<Contest> findContests = findTypeContestsByDate(nowDate, contestType);
-
         return createListOf(findContests, nowDate);
     }
 
@@ -98,12 +101,8 @@ public class ContestService {
     }
 
     private Contest getContestById(String contestId) {
-        return contestRepository.findContestById(new ObjectId(contestId));
+        return contestRepository.findContestById(new ObjectId(contestId))
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.CONTEST_NOT_FOUND));
     }
 
-    private void findContestTitleByIdTest(String contestId) {
-        // new ObjectId를 통해 String을 감싸서 보내줘야합니다.
-        Contest findContest = contestRepository.findContestById(new ObjectId(contestId));
-        findContest.getTitle();
-    }
 }

--- a/src/main/java/com/kusithm/meetupd/domain/team/service/TeamService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/team/service/TeamService.java
@@ -27,8 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.kusithm.meetupd.common.error.ErrorCode.ALREADY_USER_OPEN_TEAM;
-import static com.kusithm.meetupd.common.error.ErrorCode.USER_NOT_FOUND;
+import static com.kusithm.meetupd.common.error.ErrorCode.*;
 import static com.kusithm.meetupd.domain.team.entity.TeamUserRoleType.TEAM_LEADER;
 import static com.kusithm.meetupd.domain.team.entity.TeamUserRoleType.TEAM_MEMBER;
 
@@ -88,7 +87,8 @@ public class TeamService {
     }
 
     private Contest findContest(String contestId) {
-        return contestRepository.findContestById(new ObjectId(contestId));
+        return contestRepository.findContestById(new ObjectId(contestId))
+                .orElseThrow(() -> new EntityNotFoundException(CONTEST_NOT_FOUND));
     }
 
     public List<Team> findTeamByContentIdAndProgress(String contestId, Integer teamProgress) {


### PR DESCRIPTION
## Related Issue 🪢

- close : #60 

## Summary 🌿

- 공모전 상세 정보 보는 응답값에 남은 일수 데이터를 추가했습니다

## Before i request PR review 🧤

- 공모전 findById 하는거에서 Optional을 추가해서 TeamService에 코드도 살짝쿵 수정했는데 혹시 땡기고 그 부분 충돌나면 개발하던거로 합치고 orElseThrow만 달아주세용
