### PR TITLE
공모전 지원 날짜 지난 팀 진행상황 변경 스케줄러

### DIFF
--- a/src/main/java/com/kusithm/meetupd/domain/contest/mongo/ContestRepository.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/mongo/ContestRepository.java
@@ -2,7 +2,6 @@ package com.kusithm.meetupd.domain.contest.mongo;
 
 import com.kusithm.meetupd.domain.contest.entity.Contest;
 import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.core.query.TextCriteria;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
@@ -20,4 +19,7 @@ public interface ContestRepository extends MongoRepository<Contest, String> {
 
     @Query(value = "{_id : {$eq : ?0}}")
     Optional<Contest> findContestById(ObjectId contestId);
+
+    @Query(value = "{recruit_end : {$gte : ?0, $lt : ?1}}")
+    List<Contest> findAllEndContestsToday(LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/kusithm/meetupd/domain/contest/service/ContestService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/contest/service/ContestService.java
@@ -53,6 +53,17 @@ public class ContestService {
         Contest findContest = getContestById(contestId);
         return GetContestDetailInfoResponseDto.of(findContest, LocalDate.now());
     }
+
+    public List<Contest> findRecruitEndContests() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(1);
+        return findTodayRecruitEndContestsByDate(startDate, endDate);
+    }
+
+    private List<Contest> findTodayRecruitEndContestsByDate(LocalDate startDate, LocalDate endDate) {
+        return contestRepository.findAllEndContestsToday(startDate, endDate);
+    }
+
     private List<Contest> getContestsBySearchText(String searchText) {
         MongoDatabase database = mongoClient.getDatabase("wanteam-db");
         MongoCollection<Document> collection = database.getCollection("contest");

--- a/src/main/java/com/kusithm/meetupd/domain/team/entity/TeamProgressType.java
+++ b/src/main/java/com/kusithm/meetupd/domain/team/entity/TeamProgressType.java
@@ -15,7 +15,7 @@ public enum TeamProgressType {
 
     RECRUITING(1,"모집중"),
     RECRUITMENT_COMPLETED(2,"모집완료"),
-    PROCEDDING(3,"진행중"),
+    PROCEEDING(3,"진행중"),
     PROGRESS_ENDED(4,"진행종료");
 
     private final Integer number;

--- a/src/main/java/com/kusithm/meetupd/domain/team/scheduler/TeamScheduler.java
+++ b/src/main/java/com/kusithm/meetupd/domain/team/scheduler/TeamScheduler.java
@@ -1,5 +1,7 @@
 package com.kusithm.meetupd.domain.team.scheduler;
 
+import com.kusithm.meetupd.domain.contest.entity.Contest;
+import com.kusithm.meetupd.domain.contest.service.ContestService;
 import com.kusithm.meetupd.domain.team.entity.Team;
 import com.kusithm.meetupd.domain.team.service.TeamService;
 import jakarta.mail.MessagingException;
@@ -20,12 +22,21 @@ import java.util.List;
 public class TeamScheduler {
 
     private final TeamService teamService;
+    private final ContestService contestService;
 
     // 팀 리뷰날짜 확인하여 지났으면 팀 활동이 종료되었으니 리뷰보내라고 메일전송
-    @Scheduled(cron = "10 0 12 * * *")
-    public void scheduleTaskTeamUpdateTeamProgressEnd() throws MessagingException, UnsupportedEncodingException {
+    @Scheduled(cron = "0 1 0 * * *")
+    public void scheduleTaskUpdateTeamProgressEnd() throws MessagingException, UnsupportedEncodingException {
         List<Team> teams = teamService.updateTeamProgressEnd();
         log.info("updateTeamProgressEnd schedule tasks - {}", LocalDate.now());
         teams.forEach(it -> log.info("updated team id - {}", it.getId()));
+    }
+
+    // 공모전 모집 일자 마감됐으면 해당 공모전에 팀들 상태 활동중으로 변경하기
+    @Scheduled(cron = "1 0 0 * * *")
+    public void scheduleTaskUpdateTeamProgressProceeding() {
+        List<Contest> todayRecruitEndContests = contestService.findRecruitEndContests();
+        todayRecruitEndContests.forEach(contest -> teamService.updateTeamProgressProceeding(contest.getId()));
+        log.info("updateTeamProgressProceeding schedule tasks - {}", LocalDate.now());
     }
 }

--- a/src/main/java/com/kusithm/meetupd/domain/team/service/TeamService.java
+++ b/src/main/java/com/kusithm/meetupd/domain/team/service/TeamService.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 import static com.kusithm.meetupd.common.error.ErrorCode.*;
 import static com.kusithm.meetupd.domain.team.entity.TeamProgressType.*;
-import static com.kusithm.meetupd.domain.team.entity.TeamProgressType.PROCEDDING;
+import static com.kusithm.meetupd.domain.team.entity.TeamProgressType.PROCEEDING;
 import static com.kusithm.meetupd.domain.team.entity.TeamProgressType.RECRUITING;
 import static com.kusithm.meetupd.domain.team.entity.TeamUserRoleType.*;
 import static com.kusithm.meetupd.domain.team.entity.TeamUserRoleType.TEAM_LEADER;
@@ -113,6 +113,11 @@ public class TeamService {
         List<User> teamMember = findTeamMember(teamId);
         int status = decideStatus(userId, teamLeader.getId(), teamId);
         return TeamDetailResponseDto.of(team, teamLeader, teamMember, status);
+    }
+
+    public void updateTeamProgressProceeding(String contestId) {
+        List<Team> teams = findTeamByContentIdAndProgress(contestId, RECRUITMENT_COMPLETED.getNumber());
+        teams.forEach(team -> team.updateProgress(PROCEEDING));
     }
 
     private int decideStatus(Long userId, Long leaderId, Long teamId) {
@@ -316,7 +321,7 @@ public class TeamService {
         List<TeamUser> teamUserProceed = findTeamUserLessThan(userId, role);
         for (TeamUser teamUser : teamUserProceed) {
             Team team = teamUser.getTeam();
-            if (team.getProgress().equals(PROCEDDING.getNumber())) {
+            if (team.getProgress().equals(PROCEEDING.getNumber())) {
                 Long teamId = team.getId();
                 Contest contest = findContest(team.getContestId());
                 User leader = findTeamLeader(teamId);
@@ -363,7 +368,7 @@ public class TeamService {
 
     private List<Team> getReviewDateAfterTeam(Date date) {
         System.out.println(date);
-        return teamRepository.findAllByReviewDateLessThanAndProgress(date, PROCEDDING.getNumber());
+        return teamRepository.findAllByReviewDateLessThanAndProgress(date, PROCEEDING.getNumber());
     }
 
     private List<TeamUser> findTeamUserIApplied(Long userId, Integer role) {


### PR DESCRIPTION
## Related Issue 🪢

- close : #103 

## Summary 🌿

- 공모전 지원 날짜 지난 팀들 중 모집완료 팀의 상태를 진행 중으로 변경합니다.

## Before i request PR review 🧤

- TeamService 쪽 머지 조심조심..!!
